### PR TITLE
Remove Config from main class

### DIFF
--- a/JekyllBlogCommentsAzure/WebConfigurator.cs
+++ b/JekyllBlogCommentsAzure/WebConfigurator.cs
@@ -1,0 +1,21 @@
+﻿using System.Configuration;
+
+namespace JekyllBlogCommentsAzure
+{
+    public class WebConfigurator
+    {
+        public string CommentWebsiteUrl => ConfigurationManager.AppSettings["CommentWebsiteUrl"];
+
+        public string GitHubToken => ConfigurationManager.AppSettings["GitHubToken"];
+
+        public string PullRequestRepository => ConfigurationManager.AppSettings["PullRequestRepository"];
+
+        public string CommentFallbackCommitEmail => ConfigurationManager.AppSettings["CommentFallbackCommitEmail"];
+
+        public string SentimentAnalysisSubscriptionKey => ConfigurationManager.AppSettings["SentimentAnalysis.SubscriptionKey"];
+
+        public string SentimentAnalysisRegion => ConfigurationManager.AppSettings["SentimentAnalysis.Region"];
+
+        public string SentimentAnalysisLang => ConfigurationManager.AppSettings["SentimentAnalysis.Lang"];
+    }
+}


### PR DESCRIPTION
This PR would be a suggestion to change all of config params to a class, and read from then.

Indeed if we need to add more param's would be hard to find all of names that we need to added in Azure Functions. 